### PR TITLE
allow for multiple trust bundles to be specified in the same ConfigMap

### DIFF
--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -285,9 +285,6 @@ def call(Map paramsMap) {
         - name: trusted-ca
           configMap:
             name: ${params.trustedCABundleConfigMapName}
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
     """ : ""
 
     /* Combine this app's local config with platform-level config, if separatePlatformConfig == true */

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -236,9 +236,6 @@ def call(Map paramsMap) {
         - name: trusted-ca
           configMap:
             name: ${params.trustedCABundleConfigMapName}
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
     """ : ""
 
     /* Combine this app's local config with platform-level config, if separatePlatformConfig == true */

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -245,9 +245,6 @@ def call(Map paramsMap) {
         - name: trusted-ca
           configMap:
             name: ${params.trustedCABundleConfigMapName}
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
     """ : ""
 
     /* Combine this app's local config with platform-level config, if separatePlatformConfig == true */

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -270,9 +270,6 @@ def call(Map paramsMap) {
         - name: trusted-ca
           configMap:
             name: ${params.trustedCABundleConfigMapName}
-            items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
     """ : ""
 
     /* Combine this app's local config with platform-level config, if separatePlatformConfig == true */


### PR DESCRIPTION
# purpose

currently things are hard coded so you can only have one trust bundle in the config map but there is no reason we should be hard coded to one specific key, config map will map in all the keys to allow for muliple files if we just get rid of the hard coding.

# testing

tested in live environment and worked great.