### PR TITLE
adding var WORKFLOW_WORKER_VENV_PATH

### DIFF
--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -247,6 +247,9 @@ def call(Map paramsMap) {
     /* Name of the virtual environment to set up in the given home worksapce. */
     String WORKFLOW_WORKER_VENV_NAME = 'venv-ploigos'
 
+    /* Path to virtual python environment that PSR is in and/or will be installed into, must be on a persistent volume that can be shared between containers */
+    String WORKFLOW_WORKER_VENV_PATH = "${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}/${WORKFLOW_WORKER_VENV_NAME}"
+
     /* Directory into which platform configuration is mounted, if applicable */
     String PLATFORM_CONFIG_DIR = "/opt/platform-config"
 
@@ -461,7 +464,7 @@ def call(Map paramsMap) {
                             STEP_RUNNER_LIB_EXTRA_INDEX_URL = "${params.stepRunnerLibExtraIndexUrl}"
                             STEP_RUNNER_LIB_VERSION         = "${params.stepRunnerLibVersion}"
                             STEP_RUNNER_PACKAGE_NAME        = "${params.stepRunnerPackageName}"
-                            VENV_NAME                       = "${WORKFLOW_WORKER_VENV_NAME}"
+                            WORKFLOW_WORKER_VENV_PATH       = "${WORKFLOW_WORKER_VENV_PATH}"
                             VERBOSE                         = "${params.verbose}"
                         }
                         steps {
@@ -484,7 +487,7 @@ def call(Map paramsMap) {
                                         echo "**********************"
                                         echo "* Create Python venv *"
                                         echo "**********************"
-                                        python -m venv --system-site-packages --copies ${HOME}/${VENV_NAME}
+                                        python -m venv --system-site-packages --copies ${WORKFLOW_WORKER_VENV_PATH}
                                     '''
 
                                     sh '''
@@ -497,7 +500,7 @@ def call(Map paramsMap) {
                                             echo "* Update Python Pip *"
                                             echo "*********************"
 
-                                            source ${HOME}/${VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             python -m pip install --upgrade pip
 
                                             if [[ ${STEP_RUNNER_LIB_SOURCE_URL} ]]; then
@@ -564,7 +567,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-metadata
@@ -579,7 +582,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step tag-source
@@ -594,7 +597,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step unit-test
@@ -609,7 +612,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step package
@@ -624,7 +627,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step static-code-analysis
@@ -639,7 +642,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step push-artifacts
@@ -654,7 +657,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step create-container-image
@@ -671,7 +674,7 @@ def call(Map paramsMap) {
                                             if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                             set -eu -o pipefail
 
-                                            source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             psr \
                                                 --config ${PSR_CONFIG_ARG} \
                                                 --step container-image-static-compliance-scan
@@ -686,7 +689,7 @@ def call(Map paramsMap) {
                                             if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                             set -eu -o pipefail
 
-                                            source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             psr \
                                                 --config ${PSR_CONFIG_ARG} \
                                                 --step container-image-static-vulnerability-scan
@@ -703,7 +706,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step push-container-image
@@ -718,7 +721,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step sign-container-image
@@ -734,7 +737,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-evidence
@@ -769,7 +772,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step audit-attestation \
@@ -785,7 +788,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -801,7 +804,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step validate-environment-configuration \
@@ -817,7 +820,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step uat \
@@ -834,7 +837,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-evidence \
@@ -871,7 +874,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step audit-attestation \
@@ -887,7 +890,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -903,7 +906,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step validate-environment-configuration \
@@ -919,7 +922,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step uat \
@@ -936,7 +939,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-evidence \
@@ -972,7 +975,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step audit-attestation \
@@ -988,7 +991,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -1004,7 +1007,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step validate-environment-configuration \
@@ -1021,7 +1024,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-evidence \
@@ -1040,7 +1043,7 @@ def call(Map paramsMap) {
                         if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                         set -eu -o pipefail
 
-                        source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                        source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                         psr \
                             --config ${PSR_CONFIG_ARG} \
                             --step report

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -197,6 +197,9 @@ def call(Map paramsMap) {
 
     /* Name of the virtual environment to set up in the given home worksapce. */
     String WORKFLOW_WORKER_VENV_NAME = 'venv-ploigos'
+	
+    /* Path to virtual python environment that PSR is in and/or will be installed into, must be on a persistent volume that can be shared between containers */
+    String WORKFLOW_WORKER_VENV_PATH = "${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}/${WORKFLOW_WORKER_VENV_NAME}"
 
     /* Directory into which platform configuration is mounted, if applicable */
     String PLATFORM_CONFIG_DIR = "/opt/platform-config"
@@ -345,7 +348,7 @@ def call(Map paramsMap) {
                             STEP_RUNNER_LIB_EXTRA_INDEX_URL = "${params.stepRunnerLibExtraIndexUrl}"
                             STEP_RUNNER_LIB_VERSION         = "${params.stepRunnerLibVersion}"
                             STEP_RUNNER_PACKAGE_NAME        = "${params.stepRunnerPackageName}"
-                            VENV_NAME                       = "${WORKFLOW_WORKER_VENV_NAME}"
+                            WORKFLOW_WORKER_VENV_PATH       = "${WORKFLOW_WORKER_VENV_PATH}"
                             VERBOSE                         = "${params.verbose}"
                         }
                         steps {
@@ -368,7 +371,7 @@ def call(Map paramsMap) {
                                         echo "**********************"
                                         echo "* Create Python venv *"
                                         echo "**********************"
-                                        python -m venv --system-site-packages --copies ${HOME}/${VENV_NAME}
+                                        python -m venv --system-site-packages --copies ${WORKFLOW_WORKER_VENV_PATH}
                                     '''
 
                                     sh '''
@@ -381,7 +384,7 @@ def call(Map paramsMap) {
                                             echo "* Update Python Pip *"
                                             echo "*********************"
 
-                                            source ${HOME}/${VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             python -m pip install --upgrade pip
 
                                             if [[ ${STEP_RUNNER_LIB_SOURCE_URL} ]]; then
@@ -485,7 +488,7 @@ def call(Map paramsMap) {
                                             if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                             set -eu -o pipefail
 
-                                            source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             psr \
                                                 --config ${PSR_CONFIG_ARG} \
                                                 --step container-image-static-compliance-scan \
@@ -501,7 +504,7 @@ def call(Map paramsMap) {
                                             if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                             set -eu -o pipefail
 
-                                            source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             psr \
                                                 --config ${PSR_CONFIG_ARG} \
                                                 --step container-image-static-vulnerability-scan \
@@ -523,7 +526,7 @@ def call(Map paramsMap) {
                         if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                         set -eu -o pipefail
 
-                        source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                        source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                         # NOTE: only passing service-name becasue its currently a required value
                         psr \
                             --config ${PSR_CONFIG_ARG} \

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -206,7 +206,10 @@ def call(Map paramsMap) {
 
     /* Name of the virtual environment to set up in the given home worksapce. */
     String WORKFLOW_WORKER_VENV_NAME = 'venv-ploigos'
-
+    
+    /* Path to virtual python environment that PSR is in and/or will be installed into, must be on a persistent volume that can be shared between containers */
+    String WORKFLOW_WORKER_VENV_PATH = "${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}/${WORKFLOW_WORKER_VENV_NAME}"
+    
     /* Directory into which platform configuration is mounted, if applicable */
     String PLATFORM_CONFIG_DIR = "/opt/platform-config"
 
@@ -347,7 +350,7 @@ def call(Map paramsMap) {
                             STEP_RUNNER_LIB_EXTRA_INDEX_URL = "${params.stepRunnerLibExtraIndexUrl}"
                             STEP_RUNNER_LIB_VERSION         = "${params.stepRunnerLibVersion}"
                             STEP_RUNNER_PACKAGE_NAME        = "${params.stepRunnerPackageName}"
-                            VENV_NAME                       = "${WORKFLOW_WORKER_VENV_NAME}"
+                            WORKFLOW_WORKER_VENV_PATH       = "${WORKFLOW_WORKER_VENV_PATH}"
                             VERBOSE                         = "${params.verbose}"
                         }
                         steps {
@@ -370,7 +373,7 @@ def call(Map paramsMap) {
                                         echo "**********************"
                                         echo "* Create Python venv *"
                                         echo "**********************"
-                                        python -m venv --system-site-packages --copies ${HOME}/${VENV_NAME}
+                                        python -m venv --system-site-packages --copies ${WORKFLOW_WORKER_VENV_PATH}
                                     '''
 
                                     sh '''
@@ -383,7 +386,7 @@ def call(Map paramsMap) {
                                             echo "* Update Python Pip *"
                                             echo "*********************"
 
-                                            source ${HOME}/${VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             python -m pip install --upgrade pip
 
                                             if [[ ${STEP_RUNNER_LIB_SOURCE_URL} ]]; then
@@ -450,7 +453,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-metadata
@@ -465,7 +468,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step package
@@ -480,7 +483,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step create-container-image
@@ -495,7 +498,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step push-container-image
@@ -529,7 +532,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -564,7 +567,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -599,7 +602,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -618,7 +621,7 @@ def call(Map paramsMap) {
                         if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                         set -eu -o pipefail
 
-                        source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                        source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                         psr \
                             --config ${PSR_CONFIG_ARG} \
                             --step report

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -231,6 +231,9 @@ def call(Map paramsMap) {
 
     /* Name of the virtual environment to set up in the given home worksapce. */
     String WORKFLOW_WORKER_VENV_NAME = 'venv-ploigos'
+    
+    /* Path to virtual python environment that PSR is in and/or will be installed into, must be on a persistent volume that can be shared between containers */
+    String WORKFLOW_WORKER_VENV_PATH = "${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}/${WORKFLOW_WORKER_VENV_NAME}"
 
     /* Directory into which platform configuration is mounted, if applicable */
     String PLATFORM_CONFIG_DIR = "/opt/platform-config"
@@ -417,7 +420,7 @@ def call(Map paramsMap) {
                             STEP_RUNNER_LIB_EXTRA_INDEX_URL = "${params.stepRunnerLibExtraIndexUrl}"
                             STEP_RUNNER_LIB_VERSION         = "${params.stepRunnerLibVersion}"
                             STEP_RUNNER_PACKAGE_NAME        = "${params.stepRunnerPackageName}"
-                            VENV_NAME                       = "${WORKFLOW_WORKER_VENV_NAME}"
+                            WORKFLOW_WORKER_VENV_PATH       = "${WORKFLOW_WORKER_VENV_PATH}"
                             VERBOSE                         = "${params.verbose}"
                         }
                         steps {
@@ -440,7 +443,7 @@ def call(Map paramsMap) {
                                         echo "**********************"
                                         echo "* Create Python venv *"
                                         echo "**********************"
-                                        python -m venv --system-site-packages --copies ${HOME}/${VENV_NAME}
+                                        python -m venv --system-site-packages --copies ${WORKFLOW_WORKER_VENV_PATH}
                                     '''
 
                                     sh '''
@@ -453,7 +456,7 @@ def call(Map paramsMap) {
                                             echo "* Update Python Pip *"
                                             echo "*********************"
 
-                                            source ${HOME}/${VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             python -m pip install --upgrade pip
 
                                             if [[ ${STEP_RUNNER_LIB_SOURCE_URL} ]]; then
@@ -520,7 +523,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step generate-metadata
@@ -535,7 +538,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step tag-source
@@ -550,7 +553,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step unit-test
@@ -565,7 +568,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step package
@@ -580,7 +583,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step static-code-analysis
@@ -595,7 +598,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step push-artifacts
@@ -610,7 +613,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step create-container-image
@@ -627,7 +630,7 @@ def call(Map paramsMap) {
                                             if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                             set -eu -o pipefail
 
-                                            source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                            source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                             psr \
                                                 --config ${PSR_CONFIG_ARG} \
                                                 --step container-image-static-vulnerability-scan
@@ -644,7 +647,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step push-container-image
@@ -678,7 +681,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -694,7 +697,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step uat \
@@ -729,7 +732,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -745,7 +748,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step uat \
@@ -780,7 +783,7 @@ def call(Map paramsMap) {
                                     if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                                     set -eu -o pipefail
 
-                                    source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                                    source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                                     psr \
                                         --config ${PSR_CONFIG_ARG} \
                                         --step deploy \
@@ -799,7 +802,7 @@ def call(Map paramsMap) {
                         if [ "${params.verbose}" == "true" ]; then set -x; else set +x; fi
                         set -eu -o pipefail
 
-                        source ${HOME}/${WORKFLOW_WORKER_VENV_NAME}/bin/activate
+                        source ${WORKFLOW_WORKER_VENV_PATH}/bin/activate
                         psr \
                             --config ${PSR_CONFIG_ARG} \
                             --step report


### PR DESCRIPTION
# purpose

currently we reference `${HOME}` in both `"` and `'` contexts. the difference is that in `"` context `${HOME}` is interpreted by groovy in the context of Jenkins and has the value of the HOME env of the JNLP container image. When `${HOME}` is interperted in the `'` context it is being interpreted at runtime by bash within the context of the container it is running in and has the value of HOME of that container. This becomes an issue if the JNLP agent image has a different HOME (such as using a different vender JNLPs image) then the rest of the container images in the worklow (like using the ploigos container images). What ends up hapepnign is the python venv gets created in the HOME of the default container, but then the otehr steps look for it in the HOME of the JNLP container, because of the mix used of `'` and `"`.

# fix

dont use home.

# integration testing

## jenkins

- [x] [minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-27/1/)
- [x] [typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-quarkus-mvn/view/change-requests/job/PR-27/)
- [x] [everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-27/)