### PR TITLE
Add resources

### DIFF
--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -329,11 +329,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -347,11 +347,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -365,11 +365,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -381,11 +381,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -397,11 +397,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -413,11 +413,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -429,11 +429,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -450,11 +450,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -466,11 +466,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -482,11 +482,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -498,11 +498,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -514,11 +514,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -530,11 +530,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -121,6 +121,18 @@ class WorkflowParams implements Serializable {
      * when running this pipeline. */
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
+    /* CPU resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsCPU = '1'
+
+    /* Memory resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsMemory = '1Gi'
+
+    /* CPU resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsCPU = '2'
+
+    /* Memory resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsMemory = '2Gi'
+
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been
      * specified for that step. */
@@ -315,6 +327,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEFAULT}
           image: "${params.workflowWorkerImageDefault}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -326,6 +345,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_AGENT}
           image: "${params.workflowWorkerImageAgent}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -337,6 +363,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_UNIT_TEST}
           image: "${params.workflowWorkerImageUnitTest}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -346,6 +379,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_PACKAGE}
           image: "${params.workflowWorkerImagePackage}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -355,6 +395,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_STATIC_CODE_ANALYSIS}
           image: "${params.workflowWorkerImageStaticCodeAnalysis}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -364,6 +411,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_PUSH_ARTIFACTS}
           image: "${params.workflowWorkerImagePushArtifacts}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -373,6 +427,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_OPERATIONS}
           image: "${params.workflowWorkerImageContainerOperations}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -387,6 +448,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_IMAGE_STATIC_COMPLIANCE_SCAN}
           image: "${params.workflowWorkerImageContainerImageStaticComplianceScan}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -396,6 +464,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_IMAGE_STATIC_VULNERABILITY_SCAN}
           image: "${params.workflowWorkerImageContainerImageStaticVulnerabilityScan}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -405,6 +480,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEPLOY}
           image: "${params.workflowWorkerImageDeploy}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -414,6 +496,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_VALIDATE_ENVIRONMENT_CONFIGURATION}
           image: "${params.workflowWorkerImageValidateEnvironmentConfiguration}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -423,6 +512,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_UAT}
           image: "${params.workflowWorkerImageUAT}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -432,6 +528,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_AUTOMATED_GOVERNANCE}
           image: "${params.workflowWorkerImageAutomatedGovernance}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -122,16 +122,16 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '1'
+    String workflowWorkersRequestsCPU = '.5'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '1Gi'
+    String workflowWorkersRequestsMemory = '500Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsCPU = '2'
+    String workflowWorkersLimitsCPU = '1'
 
     /* Memory resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsMemory = '2Gi'
+    String workflowWorkersLimitsMemory = '1Gi'
 
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been

--- a/vars/ploigosWorkflowEverything.groovy
+++ b/vars/ploigosWorkflowEverything.groovy
@@ -122,10 +122,10 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '.5'
+    String workflowWorkersRequestsCPU = '.1'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '500Mi'
+    String workflowWorkersRequestsMemory = '100Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
     String workflowWorkersLimitsCPU = '1'

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -92,6 +92,18 @@ class WorkflowParams implements Serializable {
      * when running this pipeline. */
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
+    /* CPU resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsCPU = '1'
+
+    /* Memory resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsMemory = '1Gi'
+
+    /* CPU resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsCPU = '2'
+
+    /* Memory resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsMemory = '2Gi'
+
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been
      * specified for that step. */
@@ -269,6 +281,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_AGENT}
           image: "${params.workflowWorkerImageAgent}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -280,6 +299,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEFAULT}
           image: "${params.workflowWorkerImageDefault}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -291,6 +317,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_OPERATIONS}
           image: "${params.workflowWorkerImageContainerOperations}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -305,6 +338,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_IMAGE_STATIC_COMPLIANCE_SCAN}
           image: "${params.workflowWorkerImageContainerImageStaticComplianceScan}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -314,6 +354,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_IMAGE_STATIC_VULNERABILITY_SCAN}
           image: "${params.workflowWorkerImageContainerImageStaticVulnerabilityScan}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -283,11 +283,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -301,11 +301,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -319,11 +319,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -340,11 +340,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -356,11 +356,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -93,10 +93,10 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '.5'
+    String workflowWorkersRequestsCPU = '.1'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '500Mi'
+    String workflowWorkersRequestsMemory = '100Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
     String workflowWorkersLimitsCPU = '1'

--- a/vars/ploigosWorkflowExistingContainerImageScan.groovy
+++ b/vars/ploigosWorkflowExistingContainerImageScan.groovy
@@ -93,16 +93,16 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '1'
+    String workflowWorkersRequestsCPU = '.5'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '1Gi'
+    String workflowWorkersRequestsMemory = '500Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsCPU = '2'
+    String workflowWorkersLimitsCPU = '1'
 
     /* Memory resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsMemory = '2Gi'
+    String workflowWorkersLimitsMemory = '1Gi'
 
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -289,11 +289,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -307,11 +307,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -325,11 +325,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -341,11 +341,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -362,11 +362,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -122,16 +122,16 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '1'
+    String workflowWorkersRequestsCPU = '.5'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '1Gi'
+    String workflowWorkersRequestsMemory = '500Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsCPU = '2'
+    String workflowWorkersLimitsCPU = '1'
 
     /* Memory resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsMemory = '2Gi'
+    String workflowWorkersLimitsMemory = '1Gi'
 
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -122,10 +122,10 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '.5'
+    String workflowWorkersRequestsCPU = '.1'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '500Mi'
+    String workflowWorkersRequestsMemory = '100Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
     String workflowWorkersLimitsCPU = '1'

--- a/vars/ploigosWorkflowMinimal.groovy
+++ b/vars/ploigosWorkflowMinimal.groovy
@@ -121,6 +121,18 @@ class WorkflowParams implements Serializable {
      * when running this pipeline. */
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
+    /* CPU resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsCPU = '1'
+
+    /* Memory resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsMemory = '1Gi'
+
+    /* CPU resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsCPU = '2'
+
+    /* Memory resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsMemory = '2Gi'
+
     /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been
      * specified for that step. */
@@ -275,6 +287,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEFAULT}
           image: "${params.workflowWorkerImageDefault}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -286,6 +305,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_AGENT}
           image: "${params.workflowWorkerImageAgent}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -297,6 +323,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_PACKAGE}
           image: "${params.workflowWorkerImagePackage}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -306,6 +339,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_OPERATIONS}
           image: "${params.workflowWorkerImageContainerOperations}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -320,6 +360,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEPLOY}
           image: "${params.workflowWorkerImageDeploy}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -121,6 +121,18 @@ class WorkflowParams implements Serializable {
      * when running this pipeline. */
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
+    /* CPU resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsCPU = '1'
+
+    /* Memory resource request for worker pods created when running this pipeline */
+    String workflowWorkersRequestsMemory = '1Gi'
+
+    /* CPU resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsCPU = '2'
+
+    /* Memory resource limit for worker pods created when running this pipeline */
+    String workflowWorkersLimitsMemory = '2Gi'
+
      /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been
      * specified for that step. */
@@ -300,6 +312,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEFAULT}
           image: "${params.workflowWorkerImageDefault}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -311,6 +330,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_AGENT}
           image: "${params.workflowWorkerImageAgent}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -322,6 +348,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_UNIT_TEST}
           image: "${params.workflowWorkerImageUnitTest}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -331,6 +364,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_PACKAGE}
           image: "${params.workflowWorkerImagePackage}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -340,6 +380,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_STATIC_CODE_ANALYSIS}
           image: "${params.workflowWorkerImageStaticCodeAnalysis}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -349,6 +396,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_PUSH_ARTIFACTS}
           image: "${params.workflowWorkerImagePushArtifacts}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -358,6 +412,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_OPERATIONS}
           image: "${params.workflowWorkerImageContainerOperations}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -372,6 +433,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_CONTAINER_IMAGE_STATIC_VULNERABILITY_SCAN}
           image: "${params.workflowWorkerImageContainerImageStaticVulnerabilityScan}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -381,6 +449,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_DEPLOY}
           image: "${params.workflowWorkerImageDeploy}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -390,6 +465,13 @@ def call(Map paramsMap) {
         - name: ${WORKFLOW_WORKER_NAME_UAT}
           image: "${params.workflowWorkerImageUAT}"
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
+          resources:
+            limits:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersLimitsCPU}"
+              memory: "${params.workflowWorkersLimitsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -122,10 +122,10 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '.5'
+    String workflowWorkersRequestsCPU = '.1'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '500Mi'
+    String workflowWorkersRequestsMemory = '100Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
     String workflowWorkersLimitsCPU = '1'

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -122,16 +122,16 @@ class WorkflowParams implements Serializable {
     String workflowWorkersImagePullPolicy = 'IfNotPresent'
 
     /* CPU resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsCPU = '1'
+    String workflowWorkersRequestsCPU = '.5'
 
     /* Memory resource request for worker pods created when running this pipeline */
-    String workflowWorkersRequestsMemory = '1Gi'
+    String workflowWorkersRequestsMemory = '500Mi'
 
     /* CPU resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsCPU = '2'
+    String workflowWorkersLimitsCPU = '1'
 
     /* Memory resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsMemory = '2Gi'
+    String workflowWorkersLimitsMemory = '1Gi'
 
      /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been

--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -314,11 +314,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -332,11 +332,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -350,11 +350,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -366,11 +366,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -382,11 +382,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -398,11 +398,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -414,11 +414,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           securityContext:
             capabilities:
@@ -435,11 +435,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -451,11 +451,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}
@@ -467,11 +467,11 @@ def call(Map paramsMap) {
           imagePullPolicy: "${params.workflowWorkersImagePullPolicy}"
           resources:
             limits:
-              cpu: "${params.workflowWorkersRequestsCPU}"
-              memory: "${params.workflowWorkersRequestsMemory}"
-            requests:
               cpu: "${params.workflowWorkersLimitsCPU}"
               memory: "${params.workflowWorkersLimitsMemory}"
+            requests:
+              cpu: "${params.workflowWorkersRequestsCPU}"
+              memory: "${params.workflowWorkersRequestsMemory}"
           tty: true
           volumeMounts:
           - mountPath: ${WORKFLOW_WORKER_WORKSPACE_HOME_PATH}


### PR DESCRIPTION
# Purpose
Add resource requests and limits to the workers via overwritable parameters to all pipelines. Default request set low (.1 CPU, 100Mi) due to the number for containers in some of the pipeline's pod definitions requires significant resources in order to be scheduled. Only one set of parameters currently so all containers will use the same values.

Resolves #52  

# Breaking?
No

# Integration Testing
* [Everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28everything%29/job/reference-quarkus-mvn/job/PR-74/4/display/redirect)
* [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28typical%29/job/reference-quarkus-mvn/job/PR-74/4/display/redirect)
* [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28minimal%29/job/reference-quarkus-mvn/job/PR-74/4/display/redirect)
