### PR TITLE
Increasing memory limit on agent pod

### DIFF
--- a/vars/ploigosWorkflowTypical.groovy
+++ b/vars/ploigosWorkflowTypical.groovy
@@ -131,7 +131,7 @@ class WorkflowParams implements Serializable {
     String workflowWorkersLimitsCPU = '1'
 
     /* Memory resource limit for worker pods created when running this pipeline */
-    String workflowWorkersLimitsMemory = '1Gi'
+    String workflowWorkersLimitsMemory = '2Gi'
 
      /* Container image to use when creating a workflow worker
      * to run pipeline steps when no other specific container image has been


### PR DESCRIPTION
This fixes the issue with OpenSCAP failing during the Static Image Vulnerability Scan phase of the pipeline.

# Purpose
<!--
Please describe the purpose of this pull request.
If for an enhancment please go beyond just saying "adding fuctionality X" and add a reason/use case for the functionality.
-->

# Breaking?
Yes / No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuration of existing functionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
<!--
Integration testing is key for changes to this library.
Please link to relevant workflow runs using these changes to demonstrate the changes in context.
-->
* [Everything]()
* [Typical]()
* [Minimal]()
